### PR TITLE
Fix score terms gene mismatch - fixes #186

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pathfindR
 Type: Package
 Title: Enrichment Analysis Utilizing Active Subnetworks
-Version: 2.3.0.9001
+Version: 2.3.0.9002
 Authors@R: c(person("Ege", "Ulgen",
                     role = c("cre", "cph"), 
                     email = "egeulgen@gmail.com",

--- a/R/scoring.R
+++ b/R/scoring.R
@@ -114,16 +114,21 @@ score_terms <- function(enrichment_table, exp_mat, cases = NULL, use_description
 
         genes <- c(up_genes, down_genes)
 
+        # convert gene symbols to upper case for comparison
+        genes <- toupper(genes)
+        exp_mat_genes <- rownames(exp_mat)
+        exp_mat_genes <- toupper(exp_mat_genes)
+
         # some genes may not be in exp. matrix
-        genes <- genes[genes %in% rownames(exp_mat)]
+        genes <- genes[genes %in% exp_mat_genes]
 
         if (length(genes) != 0) {
             # subset exp. matrix to include only genes
-            sub_mat <- exp_mat[rownames(exp_mat) %in% genes, , drop = FALSE]
+            sub_mat <- exp_mat[exp_mat_genes %in% genes, , drop = FALSE]
 
             current_term_score_matrix <- c()
             for (gene in genes) {
-                gene_vec <- sub_mat[rownames(sub_mat) == gene, ]
+                gene_vec <- sub_mat[toupper(rownames(sub_mat)) == gene, ]
                 gene_vec <- as.numeric(gene_vec)
                 names(gene_vec) <- colnames(sub_mat)
 

--- a/tests/testthat/test-scoring.R
+++ b/tests/testthat/test-scoring.R
@@ -1,4 +1,4 @@
-## Tests for agglomerated term scoring functions - Dec 2023
+## Tests for agglomerated term scoring functions - Jan 2024
 
 test_that("`score_terms()` -- returns score matrix", {
     mockery::stub(score_terms, "graphics::plot", NULL)
@@ -10,6 +10,38 @@ test_that("`score_terms()` -- returns score matrix", {
         plot_hmap = TRUE), "matrix")
     expect_is(score_terms(enrichment_table = small_result, exp_mat = example_experiment_matrix,
         cases = colnames(example_experiment_matrix)[1:3], plot_hmap = TRUE), "matrix")
+})
+
+test_that("`score_terms()` -- matches gene symbols correctly", {
+  toy_result <- data.frame(
+    ID = c("gset1", "gset2"),
+    Term_Description = c("gset1", "gset2"),
+    Up_regulated = "",
+    Down_regulated = c(
+      paste(paste0("Gene_", c(1, 3, 5)), collapse = ", "),
+      paste(paste0("Gene_", c(6, 8)), collapse = ", ")
+    )
+  )
+  toy_result2 <- data.frame(
+    ID = c("gset1", "gset2"),
+    Term_Description = c("gset1", "gset2"),
+    Up_regulated = "",
+    Down_regulated = c(
+      paste(paste0("Dummy_", c(1, 3, 5)), collapse = ", "),
+      paste(paste0("Gene_", c(6, 8)), collapse = ", ")
+    )
+  )
+  toy_exp_mat <- matrix(
+    rnorm(40), nrow = 10, ncol = 4, dimnames = list(paste0("gene_", 1:10), paste0("subject_", 1:4))
+  )
+  expect_is(res_mat <- score_terms(enrichment_table = toy_result, exp_mat = toy_exp_mat,
+                        plot_hmap = FALSE), "matrix")
+  expect_equal(nrow(res_mat), 2)
+
+
+  expect_is(res_mat <- score_terms(enrichment_table = toy_result2, exp_mat = toy_exp_mat,
+                                   plot_hmap = FALSE), "matrix")
+  expect_equal(nrow(res_mat), 1)
 })
 
 test_that("`score_terms()` -- argument checks work", {


### PR DESCRIPTION
In this PR:

- fixed #186 by capitalising all gene symbols before attempting to match in the `score_terms` function
- updated tests accordingly to cover various scenarios