### PR TITLE
Remove KEGG ID to gene name conversion from `get_kegg_gsets`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pathfindR
 Type: Package
 Title: Enrichment Analysis Utilizing Active Subnetworks
-Version: 2.4.0.9000
+Version: 2.4.0.9001
 Authors@R: c(person("Ege", "Ulgen",
                     role = c("cre", "cph"), 
                     email = "egeulgen@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pathfindR (development version)
 
+# Minor Changes and Bug Fixes
+
+- fixed a bug regarding KEGG gene set fetching: removed the conversion functionality in `get_kegg_gsets()` which now returns KEGG IDs so that the user can convert the returned identifiers using a more appropriate tool (e.g. BioMart) should they wish
+
 # pathfindR 2.4.0
 
 ## Major Changes

--- a/man/get_kegg_gsets.Rd
+++ b/man/get_kegg_gsets.Rd
@@ -12,7 +12,7 @@ of all available organisms, see \url{https://www.genome.jp/kegg/catalog/org_list
 }
 \value{
 list containing 2 elements: \itemize{
-\item{gene_sets - A list containing the genes involved in each KEGG pathway}
+\item{gene_sets - A list containing NCBI gene IDs for the genes involved in each KEGG pathway}
 \item{descriptions - A named vector containing the descriptions for each KEGG pathway}
 }
 }

--- a/tests/testthat/test-data_generation.R
+++ b/tests/testthat/test-data_generation.R
@@ -92,17 +92,11 @@ test_that("`gset_list_from_gmt()` -- works as expected", {
 
 test_that("`get_kegg_gsets()` -- works as expected", {
   skip_on_cran()
-  mock_responses <- c(
-    httr::content(httr::GET(paste0("https://rest.kegg.jp/list/eco")), "text"),
-    "eco00010\tdescription\neco00071\tdescription2"
-  )
-
-  call_count <- 0
+  mock_response <- "eco00010\tdescription\neco00071\tdescription2"
 
   # function to manage sequential responses
   mock_content <- function(...) {
-    call_count <<- call_count + 1
-    return(mock_responses[call_count])
+    return(mock_response)
   }
 
 


### PR DESCRIPTION
This PR removes the conversion functionality in `get_kegg_gsets()` which now returns KEGG IDs so that the user can convert the returned identifiers using a more appropriate tool (e.g. BioMart) should they wish

fixes #205 