### PR TITLE
Future proofing for new ggplot2 release

### DIFF
--- a/tests/testthat/test-scoring.R
+++ b/tests/testthat/test-scoring.R
@@ -89,31 +89,37 @@ test_that("`plot_scores()` -- creates term score heatmap ggplot object with corr
         g <- plot_scores(score_mat)
         expect_is(g, "ggplot")
         
-        
-        expect_identical(g$labels$fill, "Score")
-        expect_identical(ggplot2::get_labs(g)$x, "Sample")
-        expect_identical(ggplot2::get_labs(g)$y, "Term")
+        labels <- ggplot2::get_labs(g)
+        expect_identical(labels$fill, "Score")
+        expect_identical(labels$x, "Sample")
+        expect_identical(labels$y, "Term")
 
         # cases provided
         g <- plot_scores(score_mat, cases = colnames(score_mat)[1:3])
         expect_is(g, "ggplot")
-        expect_identical(g$labels$fill, "Score")
-        expect_identical(ggplot2::get_labs(g)$x, "Sample")
-        expect_identical(ggplot2::get_labs(g)$y, "Term")
+        
+        labels <- ggplot2::get_labs(g)
+        expect_identical(labels$fill, "Score")
+        expect_identical(labels$x, "Sample")
+        expect_identical(labels$y, "Term")
 
         # default - label_samples = FALSE
         g <- plot_scores(score_mat, label_samples = FALSE)
         expect_is(g, "ggplot")
-        expect_identical(g$labels$fill, "Score")
-        expect_identical(ggplot2::get_labs(g)$x, "Sample")
-        expect_identical(ggplot2::get_labs(g)$y, "Term")
+        
+        labels <- ggplot2::get_labs(g)
+        expect_identical(labels$fill, "Score")
+        expect_identical(labels$x, "Sample")
+        expect_identical(labels$y, "Term")
 
         # cases provided - label_samples = FALSE
         g <- plot_scores(score_mat, cases = colnames(score_mat)[1:3], label_samples = FALSE)
         expect_is(g, "ggplot")
-        expect_identical(g$labels$fill, "Score")
-        expect_identical(ggplot2::get_labs(g)$x, "Sample")
-        expect_identical(ggplot2::get_labs(g)$y, "Term")
+        
+        labels <- ggplot2::get_labs(g)
+        expect_identical(labels$fill, "Score")
+        expect_identical(labels$x, "Sample")
+        expect_identical(labels$y, "Term")
     })
 
 test_that("`plot_scores()` -- argument checks work", {

--- a/tests/testthat/test-scoring.R
+++ b/tests/testthat/test-scoring.R
@@ -88,30 +88,32 @@ test_that("`plot_scores()` -- creates term score heatmap ggplot object with corr
         # default
         g <- plot_scores(score_mat)
         expect_is(g, "ggplot")
+        
+        
         expect_identical(g$labels$fill, "Score")
-        expect_identical(g$labels$x, "Sample")
-        expect_identical(g$labels$y, "Term")
+        expect_identical(ggplot2::get_labs(g)$x, "Sample")
+        expect_identical(ggplot2::get_labs(g)$y, "Term")
 
         # cases provided
         g <- plot_scores(score_mat, cases = colnames(score_mat)[1:3])
         expect_is(g, "ggplot")
         expect_identical(g$labels$fill, "Score")
-        expect_identical(g$labels$x, "Sample")
-        expect_identical(g$labels$y, "Term")
+        expect_identical(ggplot2::get_labs(g)$x, "Sample")
+        expect_identical(ggplot2::get_labs(g)$y, "Term")
 
         # default - label_samples = FALSE
         g <- plot_scores(score_mat, label_samples = FALSE)
         expect_is(g, "ggplot")
         expect_identical(g$labels$fill, "Score")
-        expect_identical(g$labels$x, "Sample")
-        expect_identical(g$labels$y, "Term")
+        expect_identical(ggplot2::get_labs(g)$x, "Sample")
+        expect_identical(ggplot2::get_labs(g)$y, "Term")
 
         # cases provided - label_samples = FALSE
         g <- plot_scores(score_mat, cases = colnames(score_mat)[1:3], label_samples = FALSE)
         expect_is(g, "ggplot")
         expect_identical(g$labels$fill, "Score")
-        expect_identical(g$labels$x, "Sample")
-        expect_identical(g$labels$y, "Term")
+        expect_identical(ggplot2::get_labs(g)$x, "Sample")
+        expect_identical(ggplot2::get_labs(g)$y, "Term")
     })
 
 test_that("`plot_scores()` -- argument checks work", {

--- a/tests/testthat/test-visualization.R
+++ b/tests/testthat/test-visualization.R
@@ -135,59 +135,71 @@ test_that("`enrichment_chart()` -- produces a ggplot object with correct labels"
         expect_is(g <- enrichment_chart(example_pathfindR_output), "ggplot")
         expect_equal(ggplot2::quo_name(g$mapping$x), "Fold_Enrichment")
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
-        expect_equal(g$labels$size, "# genes")
-        expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
-        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
+        
+        labels <- ggplot2::get_labs(g)
+        expect_equal(labels$size, "# genes")
+        expect_equal(labels$colour, expression(-log[10](p)))
+        expect_equal(labels$x, "Fold Enrichment")
+        expect_equal(labels$y, "Term_Description")
 
         # plot_by_cluster
         expect_is(g <- enrichment_chart(example_pathfindR_output_clustered, plot_by_cluster = TRUE),
             "ggplot")
         expect_equal(ggplot2::quo_name(g$mapping$x), "Fold_Enrichment")
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
-        expect_equal(g$labels$size, "# genes")
-        expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
-        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
+        
+        labels <- ggplot2::get_labs(g)
+        expect_equal(labels$size, "# genes")
+        expect_equal(labels$colour, expression(-log[10](p)))
+        expect_equal(labels$x, "Fold Enrichment")
+        expect_equal(labels$y, "Term_Description")
 
         # chang top_terms
         expect_is(g <- enrichment_chart(example_pathfindR_output, top_terms = NULL),
             "ggplot")
         expect_equal(ggplot2::quo_name(g$mapping$x), "Fold_Enrichment")
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
-        expect_equal(g$labels$size, "# genes")
-        expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
-        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
+        
+        labels <- ggplot2::get_labs(g)
+        expect_equal(labels$size, "# genes")
+        expect_equal(labels$colour, expression(-log[10](p)))
+        expect_equal(labels$x, "Fold Enrichment")
+        expect_equal(labels$y, "Term_Description")
 
         expect_is(g <- enrichment_chart(example_pathfindR_output, top_terms = 1000),
             "ggplot")
         expect_equal(ggplot2::quo_name(g$mapping$x), "Fold_Enrichment")
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
-        expect_equal(g$labels$size, "# genes")
-        expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
-        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
+        
+        labels <- ggplot2::get_labs(g)
+        expect_equal(labels$size, "# genes")
+        expect_equal(labels$colour, expression(-log[10](p)))
+        expect_equal(labels$x, "Fold Enrichment")
+        expect_equal(labels$y, "Term_Description")
 
         # change num_bubbles
         expect_is(g <- enrichment_chart(example_pathfindR_output_clustered, num_bubbles = 30),
             "ggplot")
         expect_equal(ggplot2::quo_name(g$mapping$x), "Fold_Enrichment")
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
-        expect_equal(g$labels$size, "# genes")
-        expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
-        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
+        
+        labels <- ggplot2::get_labs(g)
+        expect_equal(labels$size, "# genes")
+        expect_equal(labels$colour, expression(-log[10](p)))
+        expect_equal(labels$x, "Fold Enrichment")
+        expect_equal(labels$y, "Term_Description")
 
         # change even_breaks
         expect_is(g <- enrichment_chart(example_pathfindR_output_clustered, even_breaks = FALSE),
             "ggplot")
         expect_equal(ggplot2::quo_name(g$mapping$x), "Fold_Enrichment")
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
-        expect_equal(g$labels$size, "# genes")
-        expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
-        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
+        
+        labels <- ggplot2::get_labs(g)
+        expect_equal(labels$size, "# genes")
+        expect_equal(labels$colour, expression(-log[10](p)))
+        expect_equal(labels$x, "Fold Enrichment")
+        expect_equal(labels$y, "Term_Description")
     })
 
 test_that("`enrichment_chart()` -- argument checks work", {

--- a/tests/testthat/test-visualization.R
+++ b/tests/testthat/test-visualization.R
@@ -137,8 +137,8 @@ test_that("`enrichment_chart()` -- produces a ggplot object with correct labels"
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
         expect_equal(g$labels$size, "# genes")
         expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(g$labels$x, "Fold Enrichment")
-        expect_equal(g$labels$y, "Term_Description")
+        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
+        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
 
         # plot_by_cluster
         expect_is(g <- enrichment_chart(example_pathfindR_output_clustered, plot_by_cluster = TRUE),
@@ -147,8 +147,8 @@ test_that("`enrichment_chart()` -- produces a ggplot object with correct labels"
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
         expect_equal(g$labels$size, "# genes")
         expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(g$labels$x, "Fold Enrichment")
-        expect_equal(g$labels$y, "Term_Description")
+        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
+        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
 
         # chang top_terms
         expect_is(g <- enrichment_chart(example_pathfindR_output, top_terms = NULL),
@@ -157,8 +157,8 @@ test_that("`enrichment_chart()` -- produces a ggplot object with correct labels"
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
         expect_equal(g$labels$size, "# genes")
         expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(g$labels$x, "Fold Enrichment")
-        expect_equal(g$labels$y, "Term_Description")
+        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
+        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
 
         expect_is(g <- enrichment_chart(example_pathfindR_output, top_terms = 1000),
             "ggplot")
@@ -166,8 +166,8 @@ test_that("`enrichment_chart()` -- produces a ggplot object with correct labels"
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
         expect_equal(g$labels$size, "# genes")
         expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(g$labels$x, "Fold Enrichment")
-        expect_equal(g$labels$y, "Term_Description")
+        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
+        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
 
         # change num_bubbles
         expect_is(g <- enrichment_chart(example_pathfindR_output_clustered, num_bubbles = 30),
@@ -176,8 +176,8 @@ test_that("`enrichment_chart()` -- produces a ggplot object with correct labels"
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
         expect_equal(g$labels$size, "# genes")
         expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(g$labels$x, "Fold Enrichment")
-        expect_equal(g$labels$y, "Term_Description")
+        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
+        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
 
         # change even_breaks
         expect_is(g <- enrichment_chart(example_pathfindR_output_clustered, even_breaks = FALSE),
@@ -186,8 +186,8 @@ test_that("`enrichment_chart()` -- produces a ggplot object with correct labels"
         expect_equal(ggplot2::quo_name(g$mapping$y), "Term_Description")
         expect_equal(g$labels$size, "# genes")
         expect_equal(g$labels$colour, expression(-log[10](p)))
-        expect_equal(g$labels$x, "Fold Enrichment")
-        expect_equal(g$labels$y, "Term_Description")
+        expect_equal(ggplot2::get_labs(g)$x, "Fold Enrichment")
+        expect_equal(ggplot2::get_labs(g)$y, "Term_Description")
     })
 
 test_that("`enrichment_chart()` -- argument checks work", {


### PR DESCRIPTION
This resolves the issue raised in https://github.com/egeulgen/pathfindR/issues/223
As explained in detail in https://github.com/tidyverse/ggplot2/issues/6505, `ggplot2` will not be populating the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.
This PR updates these test assumptions as suggested.