### PR TITLE
Compatibility with upcoming igraph changes - Do not use NAs in adjacency matrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pathfindR
 Type: Package
 Title: Enrichment Analysis Utilizing Active Subnetworks
-Version: 2.5.0.9000
+Version: 2.5.0.9001
 Authors@R: c(person("Ege", "Ulgen",
                     role = c("cre", "cph"), 
                     email = "egeulgen@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pathfindR (development version)
 
+## Minor Changes and Bug Fixes
+- fixed NA values in kappa matrix generation that will cause error as part of the latest `igraph` update (#227)
+
 # pathfindR 2.5.0
 
 ## Major Changes

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -104,7 +104,7 @@ create_kappa_matrix <- function(enrichment_res, use_description = FALSE, use_act
             kappa_mat[j, i] <- kappa_mat[i, j] <- (observed - chance)/(1 - chance)
         }
     }
-
+    kappa_mat[is.na(kappa_mat)] <- 0
     return(kappa_mat)
 }
 

--- a/tests/testthat/test-clustering.R
+++ b/tests/testthat/test-clustering.R
@@ -189,7 +189,7 @@ test_that("`cluster_graph_vis()` -- coloring of 'extra' clusters work", {
     ### more than 41 clusters (number of colors available)
     selected_num_terms <- 45
     clu_input_df <- example_pathfindR_output[seq_len(selected_num_terms), ]
-    mock_kappa_mat <- matrix(NA, nrow = selected_num_terms, ncol = selected_num_terms,
+    mock_kappa_mat <- matrix(0, nrow = selected_num_terms, ncol = selected_num_terms,
         dimnames = list(clu_input_df$ID, clu_input_df$ID))
 
     # dummy hierarchical result


### PR DESCRIPTION
Changes not to use NAs in adjacency matrix